### PR TITLE
feat: Add Education section and Enhance Projects display

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,8 @@ const App = () => {
           <Hero />
         </div>
         <About />
-        < Experience />
+        <Experience />
+        <Education /> {/* Added Education component */}
         <Tech />
         <Works />
         

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+import {
+  VerticalTimeline,
+  VerticalTimelineElement,
+} from "react-vertical-timeline-component";
+import { motion } from "framer-motion";
+
+import "react-vertical-timeline-component/style.min.css";
+
+import { styles } from "../styles";
+import { SectionWrapper } from "../hoc";
+import { textVariant } from "../utils/motion";
+
+// Theme colors (from tailwind.config.cjs)
+const themeColors = {
+  ds_primary_bg: '#1A202C',
+  ds_secondary_bg: '#2D3748',
+  ds_accent: '#3182CE',
+  ds_text_primary: '#E2E8F0',
+  ds_text_secondary: '#A0AEC0',
+  ds_highlight: '#63B3ED',
+};
+
+const educationData = [
+  {
+    degree: "MSc in Data Science",
+    institution: "Addis Ababa University",
+    iconBg: themeColors.ds_accent, 
+    date: "Sept 2024 - June 2026 (Expected)",
+    points: [
+      "Statistical computing with R, Python and Pandas",
+      "Machine Learning principles and applications",
+      "Data Engineering and big data technologies",
+      "Advanced statistical modeling",
+      "Research methodologies in data science",
+    ],
+    // Placeholder for an icon. A simple div is used below.
+    // An actual academic icon (e.g., graduation cap) could be imported and used here.
+  },
+];
+
+const EducationCard = ({ educationItem }) => {
+  return (
+    <VerticalTimelineElement
+      contentStyle={{
+        background: themeColors.ds_secondary_bg,
+        color: themeColors.ds_text_primary,
+      }}
+      contentArrowStyle={{ borderRight: `7px solid ${themeColors.ds_secondary_bg}` }}
+      date={educationItem.date}
+      iconStyle={{ background: educationItem.iconBg, color: '#fff' }} // Ensure icon color is visible
+      icon={
+        // A simple placeholder div for an icon (e.g., graduation cap).
+        // Can be replaced with an actual image or SVG icon.
+        <div className='flex justify-center items-center w-full h-full'>
+          {/* Placeholder for a graduation cap icon */}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-2/3 h-2/3 text-ds-text-primary opacity-80">
+            <path d="M12 3L1 9l5 2.18V18h12V11.18L23 9 12 3zm0 3.69L17.6 9 12 11.31 6.4 9 12 6.69zM19 16H5v-3.07l7-3.11 7 3.11V16z"/>
+          </svg>
+        </div>
+      }
+    >
+      <div>
+        <h3 className='text-ds-text-primary text-[24px] font-bold'>{educationItem.degree}</h3>
+        <p
+          className='font-semibold text-ds-highlight text-[18px]'
+          style={{ margin: 0 }}
+        >
+          {educationItem.institution}
+        </p>
+      </div>
+
+      <ul className='mt-5 list-disc ml-5 space-y-2'>
+        {educationItem.points.map((point, index) => (
+          <li
+            key={`education-point-${index}`}
+            className='text-ds-text-secondary text-[14px] pl-1 tracking-wider'
+          >
+            {point}
+          </li>
+        ))}
+      </ul>
+    </VerticalTimelineElement>
+  );
+};
+
+const Education = () => {
+  return (
+    <>
+      <motion.div variants={textVariant()}>
+        <p className={`${styles.sectionSubText} text-center text-ds-text-secondary`}>
+          My Learning Journey
+        </p>
+        <h2 className={`${styles.sectionHeadText} text-center text-ds-text-primary`}>
+          Education.
+        </h2>
+      </motion.div>
+
+      <div className='mt-20 flex flex-col'>
+        <VerticalTimeline>
+          {educationData.map((item, index) => (
+            <EducationCard
+              key={`education-${index}`}
+              educationItem={item}
+            />
+          ))}
+        </VerticalTimeline>
+      </div>
+    </>
+  );
+};
+
+export default SectionWrapper(Education, "education");

--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -6,7 +6,7 @@ import { motion } from "framer-motion";
 import { styles } from "../styles";
 import { github } from "../assets";
 import { SectionWrapper } from "../hoc";
-import { projects } from "../constants";
+import { projects, technologies } from "../constants"; // Imported technologies
 import { fadeIn, textVariant } from "../utils/motion";
 
 const ProjectCard = ({
@@ -16,16 +16,20 @@ const ProjectCard = ({
   tags,
   image,
   source_code_link,
+  technologies, // Added technologies prop
 }) => {
   return (
-    <motion.div variants={fadeIn("up", "spring", index * 0.5, 0.75)}>
+    <motion.div variants={fadeIn("up", "spring", index * 0.5, 0.75)} className="group"> {/* Added group for group-hover effects */}
       <Tilt
         options={{
           max: 45,
           scale: 1,
           speed: 450,
         }}
-        className='bg-ds-secondary-bg p-5 rounded-2xl sm:w-[360px] w-full' // Updated background
+        className='bg-ds-secondary-bg p-5 rounded-2xl sm:w-[360px] w-full 
+                   transition-all duration-300 ease-in-out 
+                   hover:scale-105 hover:shadow-[0_0_20px_rgba(49,130,206,0.4)] 
+                   border border-ds-secondary-bg/60 hover:border-ds-accent/70' // Added transitions, hover effects, border
       >
         <div className='relative w-full h-[230px]'>
           <img
@@ -37,7 +41,8 @@ const ProjectCard = ({
           <div className='absolute inset-0 flex justify-end m-3 card-img_hover'>
             <div
               onClick={() => window.open(source_code_link, "_blank")}
-              className='bg-ds-accent w-10 h-10 rounded-full flex justify-center items-center cursor-pointer' // Updated GitHub icon background
+              className='bg-ds-accent w-10 h-10 rounded-full flex justify-center items-center cursor-pointer
+                         transition-transform duration-300 ease-in-out group-hover:scale-110' // Added GitHub icon hover effect
             >
               <img
                 src={github}
@@ -49,19 +54,24 @@ const ProjectCard = ({
         </div>
 
         <div className='mt-5'>
-          <h3 className='text-ds-text-primary font-bold text-[24px]'>{name}</h3> {/* Updated text color */}
-          <p className='mt-2 text-ds-text-secondary text-[14px]'>{description}</p> {/* Updated text color */}
+          <h3 className='text-ds-text-primary font-bold text-[24px]'>{name}</h3>
+          <p className='mt-2 text-ds-text-secondary text-[14px]'>{description}</p>
         </div>
 
-        <div className='mt-4 flex flex-wrap gap-2'>
-          {tags.map((tag) => (
-            <p
-              key={`${name}-${tag.name}`}
-              className={`text-[14px] ${tag.color}`}
-            >
-              #{tag.name}
-            </p>
-          ))}
+        <div className='mt-4 flex flex-wrap gap-3 items-center'> {/* Updated gap and items-center */}
+          {tags.map((tag) => {
+            const techData = technologies.find(t => t.name.toLowerCase() === tag.name.toLowerCase());
+            return (
+              <div key={`${name}-${tag.name}`} className='flex items-center gap-1 bg-ds-primary-bg/50 p-1 px-2 rounded-full'> {/* Pill style */}
+                {techData && techData.icon ? (
+                  <img src={techData.icon} alt={tag.name} className='w-4 h-4 object-contain' />
+                ) : null}
+                <p className={`text-[12px] ${techData ? 'text-ds-text-secondary' : tag.color}`}>
+                  {tag.name}
+                </p>
+              </div>
+            );
+          })}
         </div>
       </Tilt>
     </motion.div>
@@ -72,14 +82,14 @@ const Works = () => {
   return (
     <>
       <motion.div variants={textVariant()}>
-        <p className={`${styles.sectionSubText} text-ds-text-secondary`}>My work</p> {/* Added text color */}
-        <h2 className={`${styles.sectionHeadText} text-ds-text-primary`}>Projects.</h2> {/* Added text color */}
+        <p className={`${styles.sectionSubText} text-ds-text-secondary`}>My work</p>
+        <h2 className={`${styles.sectionHeadText} text-ds-text-primary`}>Projects.</h2>
       </motion.div>
 
       <div className='w-full flex'>
         <motion.p
           variants={fadeIn("", "", 0.1, 1)}
-          className='mt-3 text-ds-text-secondary text-[17px] max-w-3xl leading-[30px]' // Updated text color
+          className='mt-3 text-ds-text-secondary text-[17px] max-w-3xl leading-[30px]'
         >
           Following projects showcases my skills and experience through
           real-world examples of my work. Each project is briefly described with
@@ -91,7 +101,7 @@ const Works = () => {
 
       <div className='mt-20 flex flex-wrap gap-7'>
         {projects.map((project, index) => (
-          <ProjectCard key={`project-${index}`} index={index} {...project} />
+          <ProjectCard key={`project-${index}`} index={index} {...project} technologies={technologies} /> // Passed technologies prop
         ))}
       </div>
     </>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,6 +4,7 @@ import Navbar from "./Navbar";
 import About from "./About";
 import Tech from "./Tech";
 import Experience from "./Experience";
+import Education from "./Education"; // Added Education import
 import Works from "./Works";
 import Feedbacks from "./Feedbacks";
 import Contact from "./Contact";
@@ -16,6 +17,7 @@ export {
   About,
   Tech,
   Experience,
+  Education, // Added Education export
   Works,
   Feedbacks,
   Contact,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -36,6 +36,10 @@ export const navLinks = [
     title: "Experience", // Changed title to "Experience"
   },
   {
+    id: "education", // Added Education link
+    title: "Education",
+  },
+  {
     id: "projects", // Added new link for Projects
     title: "Projects",
   },


### PR DESCRIPTION
This commit introduces two main features:
1.  **New Education Section:**
    *   Added an 'Education' section to showcase academic qualifications.
    *   Includes details for an MSc in Data Science from Addis Ababa University, with timeline and key learning areas.
    *   Uses a vertical timeline layout consistent with the 'Experience' section and the overall data science theme.
    *   Integrated into `App.jsx` and Navbar.

2.  **Enhanced Projects (Works) Section:**
    *   Improved the visual appeal and interactivity of project cards.
    *   Added hover effects: cards now scale up and gain a theme-colored shadow.
    *   Implemented technology icons for project tags, displayed as pills, falling back to styled text if no icon is available.
    *   Refined card border styling for default and hover states.
    *   The GitHub icon on project cards now has a hover effect (scales up).