### PR TITLE
fix: Resolve ReferenceError for Education component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { BrowserRouter } from "react-router-dom";
 
-import { About, Contact, Experience, Feedbacks, Hero, Navbar, Tech, Works, StarsCanvas } from "./components";
+import { About, Contact, Experience, Education, Feedbacks, Hero, Navbar, Tech, Works, StarsCanvas } from "./components"; // Added Education
 
 const App = () => {
   return (


### PR DESCRIPTION
The Education component was being used in App.jsx without being included in the import statement from './components'. This commit adds 'Education' to the import list in App.jsx, resolving the 'ReferenceError: Education is not defined'.